### PR TITLE
feat: add in-memory caching to API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -22,10 +22,12 @@
     "prepare": "cd .. && husky install"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^2.2.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
+    "cache-manager": "^5.3.2",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0"

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { CacheModule, CacheInterceptor } from '@nestjs/cache-manager';
 
 import { GithubActivityModule } from 'nestjs-github-activity';
 
@@ -8,6 +10,7 @@ import { AppService } from './app.service';
 
 @Module({
   imports: [
+    CacheModule.register({ ttl: 10 * 60 * 1000 }), // 10 minutes
     ConfigModule.forRoot({ isGlobal: true }),
     GithubActivityModule.forRootAsync({
       imports: [ConfigModule],
@@ -21,6 +24,12 @@ import { AppService } from './app.service';
     }),
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CacheInterceptor,
+    },
+  ],
 })
 export class AppModule {}


### PR DESCRIPTION
- Add `@nestjs/cache-manager` and `cache-manager`
- Register `CacheModule` with a TTL of 10 minutes
- Add `CacheInterceptor` as a provider in `AppModule` to enable global caching