### PR TITLE
feat: enhance GitHub activity display

### DIFF
--- a/web/src/Hooks/useGithubActivities.ts
+++ b/web/src/Hooks/useGithubActivities.ts
@@ -14,7 +14,6 @@ export const useGithubActivity = () => {
     const fetchData = async () => {
       setIsLoading(true);
       try {
-        console.log(`${process.env.REACT_APP_API_BASE_URL}/github-activities`);
         const response = await fetch(
           `${process.env.REACT_APP_API_BASE_URL}/github-activities`,
         );
@@ -25,7 +24,8 @@ export const useGithubActivity = () => {
         setData(
           data.map((activity) => ({
             created_at: activity.created_at,
-            repoName: activity.repo.name,
+            repoName: activity.repo.name.split('/')[1],
+            repoUrl: activity.repo.url,
             ...getGithubActivityDetails(activity.type, activity.payload.action),
           })),
         );

--- a/web/src/Pages/Universe.tsx
+++ b/web/src/Pages/Universe.tsx
@@ -103,7 +103,15 @@ const Universe: FC = () => {
                     </p>
                   </div>
                   <p className="text-gray-500 mt-2 first-letter:uppercase">
-                    {activity.description} in the {activity.repoName}{' '}
+                    {activity.description} the{' '}
+                    <a
+                      href={activity.repoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      {activity.repoName}
+                    </a>{' '}
                     repository.
                   </p>
                 </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -55,6 +55,7 @@ export type Action = 'opened' | 'closed';
 export type DisplayedActivity = {
   created_at: string;
   repoName: string;
+  repoUrl: string;
   title: string;
   description: string;
   emoji: string;


### PR DESCRIPTION
- Cleanup console.log
- Split repo name to only display the repository name, not the full path
- Add a hyperlink to the repo