### PR TITLE
feat: implement query limit

### DIFF
--- a/api/src/app.controller.ts
+++ b/api/src/app.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get } from '@nestjs/common';
+import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
+import { Controller, Get, Inject, Query } from '@nestjs/common';
 
 import {
   GithubActivityResponse,
@@ -7,14 +8,21 @@ import {
 
 @Controller()
 export class AppController {
-  constructor(private readonly githubService: GithubActivityService) {}
+  constructor(
+    private readonly githubService: GithubActivityService,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+  ) {}
 
   @Get('/github-activities')
-  async getGitHubActivities(): Promise<GithubActivityResponse> {
-    const activities = await this.githubService.fetchGithubActivities();
+  async getGitHubActivities(
+    @Query('limit') limit = 20,
+  ): Promise<GithubActivityResponse> {
+    const cacheKey = `github-activities-${limit}`;
+    const activities = await this.githubService.fetchGithubActivities(limit);
     if (!activities) {
       throw new Error('Unable to fetch Github activities');
     }
+    await this.cacheManager.set(cacheKey, activities);
     return activities;
   }
 }

--- a/web/src/Components/LimitDropdown.tsx
+++ b/web/src/Components/LimitDropdown.tsx
@@ -1,0 +1,77 @@
+import { FC, useEffect, useRef, useState } from 'react';
+import { BsChevronDown, BsChevronUp } from 'react-icons/bs';
+
+interface LimitDropdownProps {
+  selectedLimit: number;
+  limits: number[];
+  onChange: (limit: number) => void;
+}
+
+const LimitDropdown: FC<LimitDropdownProps> = ({
+  selectedLimit,
+  limits,
+  onChange,
+}) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const handleLimitChange = (limit: number) => {
+    onChange(limit);
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!dropdownRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="
+          flex gap-1 px-2 py-1 items-center
+          border border-gray-300 rounded-md
+          focus:outline-none focus:ring-indigo-500 focus:border-indigo-500
+          cursor-pointer z-50
+        "
+      >
+        {selectedLimit}
+        {isOpen ? <BsChevronUp /> : <BsChevronDown />}
+      </button>
+      {isOpen && (
+        <ul
+          className="
+          absolute w-full mt-1
+          bg-gray-700 border-gray-300 rounded-md 
+          focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 
+          cursor-pointer z-50
+          "
+        >
+          {limits.map((limit) => (
+            <li
+              key={limit}
+              onClick={() => handleLimitChange(limit)}
+              className={`
+              rounded-md px-2 py-1
+              ${
+                selectedLimit === limit ? 'bg-indigo-500' : 'hover:bg-gray-600'
+              }`}
+            >
+              {limit}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default LimitDropdown;

--- a/web/src/Hooks/useGithubActivities.ts
+++ b/web/src/Hooks/useGithubActivities.ts
@@ -5,7 +5,7 @@ import {
   GithubActivityResponse,
 } from '../types';
 
-export const useGithubActivity = () => {
+export const useGithubActivity = (limit = 20) => {
   const [data, setData] = useState<DisplayedActivity[] | undefined>();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error>();
@@ -15,7 +15,7 @@ export const useGithubActivity = () => {
       setIsLoading(true);
       try {
         const response = await fetch(
-          `${process.env.REACT_APP_API_BASE_URL}/github-activities`,
+          `${process.env.REACT_APP_API_BASE_URL}/github-activities?limit=${limit}`,
         );
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
@@ -37,7 +37,7 @@ export const useGithubActivity = () => {
     };
 
     fetchData();
-  }, []);
+  }, [limit]);
 
   return { data, isLoading, error };
 };

--- a/web/src/Pages/Universe.tsx
+++ b/web/src/Pages/Universe.tsx
@@ -21,7 +21,7 @@ const Universe: FC = () => {
   const [showText, setShowText] = useState(false);
   const galaxyPositions = useGalaxyPositions();
   const { width, height } = getUnit();
-  const { data, isLoading, error } = useGithubActivity();
+  const { data, isLoading, error } = useGithubActivity(3);
 
   const handleGalaxyHover = (index: number | null) => {
     setHoveredGalaxy(index);

--- a/web/src/Pages/Universe.tsx
+++ b/web/src/Pages/Universe.tsx
@@ -7,6 +7,7 @@ import dayjs from 'dayjs';
 
 import { galaxyData, galaxyOrbitSpeeds } from '../constans';
 import Galaxy from '../Components/Galaxy';
+import LimitDropdown from '../Components/LimitDropdown';
 import { useGalaxyPositions } from '../Hooks/useGalaxyPositions';
 import { useGithubActivity } from '../Hooks/useGithubActivities';
 
@@ -17,11 +18,12 @@ const getUnit = () =>
     : { width: 'w-[100dvw]', height: 'h-[100dvh]' };
 
 const Universe: FC = () => {
+  const [limit, setLimit] = useState(20);
   const [hoveredGalaxy, setHoveredGalaxy] = useState<number | null>(null);
   const [showText, setShowText] = useState(false);
   const galaxyPositions = useGalaxyPositions();
   const { width, height } = getUnit();
-  const { data, isLoading, error } = useGithubActivity(3);
+  const { data, isLoading, error } = useGithubActivity(limit);
 
   const handleGalaxyHover = (index: number | null) => {
     setHoveredGalaxy(index);
@@ -76,6 +78,11 @@ const Universe: FC = () => {
       >
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-2xl font-semibold">Cosmic Activities</h2>
+          <LimitDropdown
+            selectedLimit={limit}
+            limits={[10, 20, 50, 100]}
+            onChange={(newLimit) => setLimit(newLimit)}
+          />
         </div>
         <p className="text-lg text-gray-400 mb-8">
           Witness how the universe unfolds its wonders with amazing events


### PR DESCRIPTION
- Add limit parameter to getGitHubActivities method
- Update cacheManager to cache the fetched GitHub activities
- Created a new `LimitDropdown` component for selecting the limit of GitHub activities to display
- Updated `useGithubActivity` hook to accept a `limit` parameter and pass it to the API call
- Integrated the `LimitDropdown` component into the `Universe` component in and connected it
to the `useGithubActivity` hook
